### PR TITLE
Hard code the shift for version control

### DIFF
--- a/nuclockutils/nustarclock.py
+++ b/nuclockutils/nustarclock.py
@@ -1535,7 +1535,7 @@ def main_create_clockfile(args=None):
                         help="Output file name")
     parser.add_argument("--cache", default=None,
                         help="HDF5 dump file used as cache (ext. hdf5)")
-    parser.add_argument("--shift-times", default=0, type=float,
+    parser.add_argument("--shift-times", default=4.9e-3, type=float,
                         help="Shift times by this amount")
     parser.add_argument("--save-nodetrend",
                         help="Save un-detrended correction in separate FITS "


### PR DESCRIPTION
Since this is supposed to be the default, hard code this here so that we can correlated a specific version of the code with a specific offset (in case we change something in the future). I think it makes sense to track this here and then allow for the ability to move this around in case we need to refit it someday.