### PR TITLE
High resolution and fix recent

### DIFF
--- a/nuclockutils/barycorr.py
+++ b/nuclockutils/barycorr.py
@@ -165,7 +165,6 @@ def apply_clock_correction(
                     else:
                         hdu.header[keyname] = corrected_time
 
-
             hdu.header['CREATOR'] = f'NuSTAR Clock Utils - v. {version}'
             hdu.header['DATE'] = Time.now().fits
             hdu.header['PLEPHEM'] = f'JPL-{ephem}'

--- a/nuclockutils/clean_clock/app.py
+++ b/nuclockutils/clean_clock/app.py
@@ -74,7 +74,8 @@ def recalc(outfile='save_all.pickle'):
         time_resolution=10, craig_fit=False, hdf_dump_file='dump.hdf5')
 
     table_new = eliminate_trends_in_residuals(
-        table_new, clock_offset_table_corr, gtis)
+        table_new, clock_offset_table_corr, gtis,
+        fixed_control_points=np.arange(291e6, 295e6, 86400))
 
     mets = np.array(table_new['met'])
     start = mets[0]

--- a/nuclockutils/clean_clock/app.py
+++ b/nuclockutils/clean_clock/app.py
@@ -59,8 +59,8 @@ def recalc(outfile='save_all.pickle'):
         load_and_flag_clock_table(clockfile=CLOCKFILE, shift_non_malindi=True)
 
     table_times = temptable_raw['met']
-    met_start = table_times[0]
-    met_stop = table_times[-1]
+    met_start = clock_offset_table['met'][0]
+    met_stop = clock_offset_table['met'][-1] + 30
     clock_jump_times = np.array([78708320, 79657575, 81043985, 82055671,
                                  293346772])
     clock_jump_times += 30 #  Sum 30 seconds to avoid to exclude these points
@@ -83,6 +83,7 @@ def recalc(outfile='save_all.pickle'):
 
     good_mets = clock_offset_table['met'] < stop
     clock_offset_table = clock_offset_table[good_mets]
+    # print(clock_offset_table['met'][-10:], table_new['met'][-1])
 
     clock_mets = clock_offset_table['met']
     clock_mjds = clock_offset_table['mjd']

--- a/nuclockutils/diagnostics/compare_pulses.py
+++ b/nuclockutils/diagnostics/compare_pulses.py
@@ -78,13 +78,14 @@ def main(args=None):
     mjds = []
     plt.figure(figsize=(6, 9))
     ref_profile = None
+    phase_time_plot_template, prof_plot_template = None, None
     if args.template is not None and os.path.exists(args.template):
         mjd, phase, prof, _, _, period_ms = \
             format_profile_and_get_phase(args.template, template=None)
-        phase_time_plot, prof_plot = format_for_plotting(phase, prof, period_ms)
+        phase_time_plot_template, prof_plot_template = format_for_plotting(phase, prof, period_ms)
         local_max = phase[np.argmax(prof)] * period_ms
 
-        plt.plot(phase_time_plot, prof_plot,
+        plt.plot(phase_time_plot_template, prof_plot_template,
             drawstyle='steps-mid', label=args.template, color='k')
         ref_profile = prof
         ref_max = local_max
@@ -100,13 +101,18 @@ def main(args=None):
 
         local_max = phase[np.argmax(prof)] * period_ms
 
-        phases.append(phase_res * period_ms)
+        local_phase_time = phase_res * period_ms
+        phases.append(local_phase_time)
         phase_errs.append(phase_res_err * period_ms)
         mjds.append(mjd)
         maxs.append(local_max)
 
         plt.plot(phase_time_plot, (i + 1) * 0.2 + prof_plot,
                  drawstyle='steps-mid', label=f, alpha=0.5, color='grey')
+        if phase_time_plot_template is not None:
+            plt.plot(phase_time_plot_template + local_phase_time,
+                     (i + 1) * 0.2 + prof_plot_template,
+                     drawstyle='steps-mid', label=f, alpha=0.5, color='grey')
         if len(files) < 2:
             continue
         for plot_shift in [0, period_ms, 2 * period_ms]:

--- a/nuclockutils/diagnostics/fftfit.py
+++ b/nuclockutils/diagnostics/fftfit.py
@@ -1,166 +1,204 @@
+"""Use FFT techniques to align a template with a pulse profile.
+
+This should be accompanied by test_fftfit.py, which uses hypothesis to check
+its reliability. If not, don't edit this, you don't have the git version.
+
+Anne Archibald, 2020
+
+"""
+from __future__ import division
+
 import numpy as np
-from scipy.optimize import minimize, brentq
+import scipy.optimize
+import scipy.stats
 
 
-def find_delay_with_ccf(amp, pha):
-    nh = 32
-    nprof = nh * 2
-    CCF = np.zeros(64, dtype=np.complex)
-    CCF[:nh] = amp[:nh] * np.cos(pha[:nh]) + 1.0j * amp[:nh] * np.sin(pha[:nh])
-    CCF[nprof: nprof - nh: -1] = np.conj(CCF[nprof: nprof - nh: -1])
-    CCF[nh // 2: nh] = 0
-    CCF[nprof - nh // 2: nprof - nh: -1] = 0
-    ccf = np.fft.ifft(CCF)
-
-    imax = np.argmax(ccf.real)
-    cmax = ccf[imax]
-    shift = normalize_phase_0d5(imax / nprof)
-
-    # plt.figure()
-    # plt.plot(ccf.real)
-    # plt.show()
-    # fb=np.real(cmax)
-    # ia=imax-1
-    # if(ia == -1): ia=nprof-1
-    # fa=np.real(ccf[ia])
-    # ic=imax+1
-    # if(ic == nprof): ic=0
-    # fc=np.real(ccf[ic])
-    # if ((2*fb-fc-fa) != 0):
-    #     shift=imax+0.5*(fa-fc)/(2*fb-fc-fa)
-    #     shift = normalize_phase_0d5(shift / nprof)
-    return shift
+class FFTFITResult:
+    pass
 
 
-def best_phase_func(tau, amp, pha, ngood=20):
-    # tau = params['tau']
-    # good = slice(1, idx.size // 2 + 1)
-    good = slice(1, ngood + 1)
-    idx = np.arange(1, ngood + 1, dtype=int)
-    res = np.sum(idx * amp[good] * np.sin(-pha[good] + TWOPI * idx * tau))
-    # print(tau, res)
-    return res
+def wrap(a):
+    """Wrap a floating-point number or array to the range -0.5 to 0.5."""
+    return (a + 0.5) % 1 - 0.5
 
 
-TWOPI  = 2 * np.pi
-
-def chi_sq(b, tau, P, S, theta, phi, ngood=20):
-    # tau = params['tau']
-    # good = slice(1, idx.size // 2 + 1)
-    good = slice(1, ngood + 1)
-    idx = np.arange(1, ngood + 1, dtype=int)
-    angle_diff = phi[good] - theta[good] + TWOPI * idx * tau
-    exp_term = np.exp(1.0j * angle_diff)
-
-    to_square = P[good] - b * S[good] * exp_term
-    res = np.sum((to_square * to_square.conj()))
-
-    return res.real
+def zap_nyquist(profile):
+    if len(profile) % 2:
+        return profile
+    else:
+        c = np.fft.rfft(profile)
+        c[-1] = 0
+        return np.fft.irfft(c)
 
 
-def chi_sq_alt(b, tau, P, S, theta, phi, ngood=20):
-    # tau = params['tau']
-    # good = slice(1, idx.size // 2 + 1)
-    good = slice(1, ngood + 1)
-    idx = np.arange(1, ngood + 1, dtype=int)
-    angle_diff = phi[good] - theta[good] + TWOPI * idx * tau
-    chisq_1 = P[good] ** 2 + b**2 * S[good] ** 2
-    chisq_2 = -2 * b * P[good] * S[good] * np.cos(angle_diff)
-    res = np.sum(chisq_1 + chisq_2)
-
-    return res
-
-
-def fftfit(prof, template):
-    """Align a template to a pulse profile.
-
-    Parameters
-    ----------
-    prof : array
-        The pulse profile
-    template : array, default None
-        The template of the pulse used to perform the TOA calculation. If None,
-        a simple sinusoid is used
-
-    Returns
-    -------
-    mean_amp, std_amp : floats
-        Mean and standard deviation of the amplitude
-    mean_phase, std_phase : floats
-        Mean and standard deviation of the phase
+def vonmises_profile(kappa, n, phase=0):
+    """Generate a profile based on a von Mises distribution.
+    The von Mises distribution is a cyclic analogue of a Gaussian distribution. The width is
+    specified by the parameter kappa, which for large kappa is approximately 1/(2*pi*sigma**2).
     """
-    prof = prof - np.mean(prof)
-
-    nbin = len(prof)
-
-    template = template - np.mean(template)
-
-    temp_ft = np.fft.fft(template)
-    prof_ft = np.fft.fft(prof)
-    freq = np.fft.fftfreq(prof.size)
-    good = freq == freq
-
-    P = np.abs(prof_ft[good])
-    theta = np.angle(prof_ft[good])
-    S = np.abs(temp_ft[good])
-    phi = np.angle(temp_ft[good])
-
-    assert np.allclose(temp_ft[good], S * np.exp(1.0j * phi))
-    assert np.allclose(prof_ft[good], P * np.exp(1.0j * theta))
-
-    amp = P * S
-    pha = theta - phi
-
-    mean = np.mean(amp)
-    ngood = np.count_nonzero(amp >= mean)
-
-    dph_ccf = find_delay_with_ccf(amp, pha)
-
-    idx = np.arange(0, len(P), dtype=int)
-    sigma = np.std(prof_ft[good])
-
-    def func_to_minimize(tau):
-        return best_phase_func(-tau, amp, pha, ngood=ngood)
-
-    start_val = dph_ccf
-    start_sign = np.sign(func_to_minimize(start_val))
-
-    count_down = 0
-    count_up = 0
-    trial_val_up = start_val
-    trial_val_down = start_val
-    while True:
-        if np.sign(func_to_minimize(trial_val_up)) != start_sign:
-            best_dph = trial_val_up
-            break
-        if np.sign(func_to_minimize(trial_val_down)) != start_sign:
-            best_dph = trial_val_down
-            break
-        trial_val_down -= 1/nbin
-        count_down += 1
-        trial_val_up += 1/nbin
-        count_up += 1
-
-    a, b = best_dph - 2 / nbin, best_dph + 2 / nbin
-
-    shift, res = brentq(func_to_minimize, a, b, full_output=True)
-
-    nmax = ngood
-    good = slice(1, nmax)
-
-    big_sum = np.sum(
-            idx[good] ** 2 *
-            amp[good] * np.cos(-pha[good] + 2 * np.pi * idx[good] * -shift)
+    return np.diff(
+        scipy.stats.vonmises(kappa).cdf(
+            np.linspace(-2 * np.pi * phase, 2 * np.pi * (1 - phase), n + 1)
         )
+    )
 
-    b = np.sum(amp[good] * np.cos(-pha[good] + 2 * np.pi * idx[good] * -shift)
-        ) / np.sum(S[good]**2)
 
-    eshift = sigma**2 / (2 * b * big_sum)
+def upsample(profile, factor):
+    """Produce an up-sampled version of a pulse profile.
+    This uses a Fourier algorithm, with zero in the new Fourier coefficients.
+    """
+    output_len = len(profile) * factor
+    if output_len % 2:
+        raise ValueError("Cannot cope with odd output profile lengths")
+    c = np.fft.rfft(profile)
+    output_c = np.zeros(output_len // 2 + 1, dtype=complex)
+    output_c[: len(c)] = c * factor
+    output = np.fft.irfft(output_c)
+    assert len(output) == output_len
+    return output
 
-    eb = sigma**2 / (2 * np.sum(S[good]**2))
 
-    return b, np.sqrt(eb), normalize_phase_0d5(shift), np.sqrt(eshift)
+def shift(profile, phase):
+    """Shift a profile in phase.
+    This is a shift towards later phases - if your profile has a 1 in bin zero
+    and apply a phase shift of 1/4, the 1 will now be in bin n/4.  If the
+    profile has even length, do not modify the Nyquist component.
+    """
+    c = np.fft.rfft(profile)
+    if len(profile) % 2:
+        c *= np.exp(-2.0j * np.pi * phase * np.arange(len(c)))
+    else:
+        c[:-1] *= np.exp(-2.0j * np.pi * phase * np.arange(len(c) - 1))
+    return np.fft.irfft(c, len(profile))
+
+
+def irfft_value(c, phase, n=None):
+    """Evaluate the inverse real FFT at a particular position.
+    If the phase is one of the usual grid points the result will agree with
+    the results of `np.fft.irfft` there.
+    No promises if n is small enough to imply truncation.
+    """
+    natural_n = (len(c) - 1) * 2
+    if n is None:
+        n = natural_n
+    phase = np.asarray(phase)
+    s = phase.shape
+    phase = np.atleast_1d(phase)
+    c = np.array(c)
+    c[0] /= 2
+    if n == natural_n:
+        c[-1] /= 2
+    return (
+        (
+            c[:, None]
+            * np.exp(2.0j * np.pi * phase[None, :] * np.arange(len(c))[:, None])
+        )
+        .sum(axis=0)
+        .real
+        * 2
+        / n
+    ).reshape(s)
+
+
+def fftfit_full(
+    template, profile, compute_scale=True, compute_uncertainty=True, std=None
+):
+    # We will upsample the cross-correlation function to ensure
+    # that the highest peak is not missed
+    upsample = 8
+
+    t_c = np.fft.rfft(template)
+    if len(template) % 2 == 0:
+        t_c[-1] = 0
+    p_c = np.fft.rfft(profile)
+    if len(profile) % 2 == 0:
+        p_c[-1] = 0
+    n_c = min(len(t_c), len(p_c))
+    t_c = t_c[:n_c]
+    p_c = p_c[:n_c]
+
+    ccf_c = np.conj(t_c).copy()
+    ccf_c *= p_c
+    ccf_c[0] = 0
+    n_long = 2 ** int(np.ceil(np.log2(2 * (n_c - 1) * upsample)))
+    ccf = np.fft.irfft(ccf_c, n_long)
+    i = np.argmax(ccf)
+    assert ccf[i] >= ccf[(i - 1) % len(ccf)]
+    assert ccf[i] >= ccf[(i + 1) % len(ccf)]
+    x = i / len(ccf)
+    l, r = x - 1 / len(ccf), x + 1 / len(ccf)
+
+    def gof(x):
+        return -irfft_value(ccf_c, x, n_long)
+
+    res = scipy.optimize.minimize_scalar(
+        gof, bounds=(l, r), method="Bounded", options=dict(xatol=1e-5 / n_c)
+    )
+    if not res.success:
+        raise ValueError("FFTFIT failed: %s" % res.message)
+    # assert gof(res.x) <= gof(x)
+    r = FFTFITResult()
+    r.shift = res.x % 1
+
+    if compute_scale or compute_uncertainty:
+        # shifted template corefficients
+        s_c = t_c * np.exp(-2j * np.pi * np.arange(len(t_c)) * r.shift)
+        assert len(s_c) == len(p_c)
+        n_data = 2 * len(s_c) - 1
+        a = np.zeros((n_data, 2))
+        b = np.zeros(n_data)
+        a[0, 1] = len(template)
+        a[0, 0] = s_c[0].real
+        b[0] = p_c[0].real
+        b[1 : len(p_c)] = p_c[1:].real
+        b[len(p_c) :] = p_c[1:].imag
+        a[1 : len(s_c), 0] = s_c[1:].real
+        a[len(s_c) :, 0] = s_c[1:].imag
+
+        lin_x, res, rk, s = scipy.linalg.lstsq(a, b)
+        assert lin_x.shape == (2,)
+
+        r.scale = lin_x[0]
+        r.offset = lin_x[1]
+
+        if compute_uncertainty:
+            if std is None:
+                resid = (
+                    r.scale * shift(template, r.shift) + r.offset - profile
+                )
+                std = np.sqrt(np.mean(resid ** 2))
+
+            J = np.zeros((2 * len(s_c) - 2, 2))
+            J[: len(s_c) - 1, 0] = (
+                -r.scale * 2 * np.pi * s_c[1:].imag * np.arange(1, len(s_c))
+            )
+            J[len(s_c) - 1 :, 0] = (
+                r.scale * 2 * np.pi * s_c[1:].real * np.arange(1, len(s_c))
+            )
+            J[: len(s_c) - 1, 1] = s_c[1:].real
+            J[len(s_c) - 1 :, 1] = s_c[1:].imag
+            cov = scipy.linalg.inv(np.dot(J.T, J))
+            assert cov.shape == (2, 2)
+            # FIXME: std is per data point, not per real or imaginary
+            # entry in s_c; check conversion
+            r.uncertainty = std * np.sqrt(len(profile) * cov[0, 0] / 2)
+            r.cov = cov
+
+    return r
+
+
+def fftfit_basic(template, profile):
+    """Compute the phase shift between template and profile
+
+    We should have fftfit_basic(template, shift(template, s)) == s
+    """
+    r = fftfit_full(template, profile, compute_scale=False, compute_uncertainty=False)
+    return r.shift
+
+
+def fftfit(profile, template):
+    res = fftfit_full(template, profile)
+    return res.scale, 0, normalize_phase_0d5(res.shift), res.uncertainty
 
 
 def normalize_phase_0d5(phase):

--- a/nuclockutils/diagnostics/fftfit_save.py
+++ b/nuclockutils/diagnostics/fftfit_save.py
@@ -1,0 +1,184 @@
+import numpy as np
+from scipy.optimize import minimize, brentq
+
+
+def find_delay_with_ccf(amp, pha):
+    nh = 32
+    nprof = nh * 2
+    CCF = np.zeros(64, dtype=np.complex)
+    CCF[:nh] = amp[:nh] * np.cos(pha[:nh]) + 1.0j * amp[:nh] * np.sin(pha[:nh])
+    CCF[nprof: nprof - nh: -1] = np.conj(CCF[nprof: nprof - nh: -1])
+    CCF[nh // 2: nh] = 0
+    CCF[nprof - nh // 2: nprof - nh: -1] = 0
+    ccf = np.fft.ifft(CCF)
+
+    imax = np.argmax(ccf.real)
+    cmax = ccf[imax]
+    shift = normalize_phase_0d5(imax / nprof)
+
+    # plt.figure()
+    # plt.plot(ccf.real)
+    # plt.show()
+    # fb=np.real(cmax)
+    # ia=imax-1
+    # if(ia == -1): ia=nprof-1
+    # fa=np.real(ccf[ia])
+    # ic=imax+1
+    # if(ic == nprof): ic=0
+    # fc=np.real(ccf[ic])
+    # if ((2*fb-fc-fa) != 0):
+    #     shift=imax+0.5*(fa-fc)/(2*fb-fc-fa)
+    #     shift = normalize_phase_0d5(shift / nprof)
+    return shift
+
+
+def best_phase_func(tau, amp, pha, ngood=20):
+    # tau = params['tau']
+    # good = slice(1, idx.size // 2 + 1)
+    good = slice(1, ngood + 1)
+    idx = np.arange(1, ngood + 1, dtype=int)
+    res = np.sum(idx * amp[good] * np.sin(-pha[good] + TWOPI * idx * tau))
+    # print(tau, res)
+    return res
+
+
+TWOPI  = 2 * np.pi
+
+def chi_sq(b, tau, P, S, theta, phi, ngood=20):
+    # tau = params['tau']
+    # good = slice(1, idx.size // 2 + 1)
+    good = slice(1, ngood + 1)
+    idx = np.arange(1, ngood + 1, dtype=int)
+    angle_diff = phi[good] - theta[good] + TWOPI * idx * tau
+    exp_term = np.exp(1.0j * angle_diff)
+
+    to_square = P[good] - b * S[good] * exp_term
+    res = np.sum((to_square * to_square.conj()))
+
+    return res.real
+
+
+def chi_sq_alt(b, tau, P, S, theta, phi, ngood=20):
+    # tau = params['tau']
+    # good = slice(1, idx.size // 2 + 1)
+    good = slice(1, ngood + 1)
+    idx = np.arange(1, ngood + 1, dtype=int)
+    angle_diff = phi[good] - theta[good] + TWOPI * idx * tau
+    chisq_1 = P[good] ** 2 + b**2 * S[good] ** 2
+    chisq_2 = -2 * b * P[good] * S[good] * np.cos(angle_diff)
+    res = np.sum(chisq_1 + chisq_2)
+
+    return res
+
+
+def fftfit(prof, template):
+    """Align a template to a pulse profile.
+
+    Parameters
+    ----------
+    prof : array
+        The pulse profile
+    template : array, default None
+        The template of the pulse used to perform the TOA calculation. If None,
+        a simple sinusoid is used
+
+    Returns
+    -------
+    mean_amp, std_amp : floats
+        Mean and standard deviation of the amplitude
+    mean_phase, std_phase : floats
+        Mean and standard deviation of the phase
+    """
+    prof = prof - np.mean(prof)
+
+    nbin = len(prof)
+
+    template = template - np.mean(template)
+
+    temp_ft = np.fft.fft(template)
+    prof_ft = np.fft.fft(prof)
+    freq = np.fft.fftfreq(prof.size)
+    good = freq == freq
+
+    P = np.abs(prof_ft[good])
+    theta = np.angle(prof_ft[good])
+    S = np.abs(temp_ft[good])
+    phi = np.angle(temp_ft[good])
+
+    assert np.allclose(temp_ft[good], S * np.exp(1.0j * phi))
+    assert np.allclose(prof_ft[good], P * np.exp(1.0j * theta))
+
+    amp = P * S
+    pha = theta - phi
+
+    mean = np.mean(amp)
+    ngood = np.count_nonzero(amp >= mean)
+
+    dph_ccf = find_delay_with_ccf(amp, pha)
+
+    idx = np.arange(0, len(P), dtype=int)
+    sigma = np.std(prof_ft[good])
+
+    def func_to_minimize(tau):
+        return best_phase_func(-tau, amp, pha, ngood=ngood)
+
+    start_val = dph_ccf
+    start_sign = np.sign(func_to_minimize(start_val))
+
+    count_down = 0
+    count_up = 0
+    trial_val_up = start_val
+    trial_val_down = start_val
+    while True:
+        if np.sign(func_to_minimize(trial_val_up)) != start_sign:
+            best_dph = trial_val_up
+            break
+        if np.sign(func_to_minimize(trial_val_down)) != start_sign:
+            best_dph = trial_val_down
+            break
+        trial_val_down -= 1/nbin
+        count_down += 1
+        trial_val_up += 1/nbin
+        count_up += 1
+
+    a, b = best_dph - 2 / nbin, best_dph + 2 / nbin
+
+    shift, res = brentq(func_to_minimize, a, b, full_output=True)
+
+    nmax = ngood
+    good = slice(1, nmax)
+
+    big_sum = np.sum(
+            idx[good] ** 2 *
+            amp[good] * np.cos(-pha[good] + 2 * np.pi * idx[good] * -shift)
+        )
+
+    b = np.sum(amp[good] * np.cos(-pha[good] + 2 * np.pi * idx[good] * -shift)
+        ) / np.sum(S[good]**2)
+
+    eshift = sigma**2 / (2 * b * big_sum)
+
+    eb = sigma**2 / (2 * np.sum(S[good]**2))
+
+    return b, np.sqrt(eb), normalize_phase_0d5(shift), np.sqrt(eshift)
+
+
+def normalize_phase_0d5(phase):
+    """Normalize phase between -0.5 and 0.5
+
+    Examples
+    --------
+    >>> normalize_phase_0d5(0.5)
+    0.5
+    >>> normalize_phase_0d5(-0.5)
+    0.5
+    >>> normalize_phase_0d5(4.25)
+    0.25
+    >>> normalize_phase_0d5(-3.25)
+    -0.25
+    """
+    while phase > 0.5:
+        phase -= 1
+    while phase <= -0.5:
+        phase += 1
+    return phase

--- a/nuclockutils/diagnostics/fold_to_ephemeris.py
+++ b/nuclockutils/diagnostics/fold_to_ephemeris.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from astropy import log
 from astropy.table import Table
+from astropy.io import fits
 
 import matplotlib.pyplot as plt
 from pint import models
@@ -51,7 +52,8 @@ def calculate_profile_from_phase(phase, nbin=256, expo=None):
     if expo is not None:
         prof_corr = prof / expo
 
-    t = Table({'phase': np.linspace(0, 1, nbin + 1)[:-1], 'profile': prof_corr, 'profile_raw': prof})
+    t = Table({'phase': np.linspace(0, 1, nbin + 1)[:-1] + 0.5 / nbin,
+               'profile': prof_corr, 'profile_raw': prof})
     if expo is not None:
         t['expo'] = expo
 
@@ -78,6 +80,113 @@ def prepare_TOAs(mjds, ephem):
     toalist.clock_corr_info['include_bipm'] = False
     toalist.clock_corr_info['include_gps'] = False
     return toalist
+
+
+# def get_expo_kristin(evfile, nbin, n_phot_max=1000000):
+#     with fits.open(evfile) as hdul:
+#         times = np.array(hdul[1].data['TIME'][:n_phot_max])
+#         priors = np.array(hdul[1].data['PRIOR'][:n_phot_max])
+#         mjdref = hdul[1].header['MJDREFF'] + hdul[1].header['MJDREFI']
+#
+#         for i in range(times.size):
+#             istart = np.floor((lcDT[i] - evt[i].prior) / (nbin * p0))
+#             iend = np.floor(lcDT[i] / (nbin * p0))
+#             if (istart lt 0) then begin
+#             livetime[0:iend] += 1
+#             livetime[200 + istart: *] += 1
+#
+#
+#     endif
+#     if (istart ge 0) then begin
+#     if (iend eq 200) then begin
+#     iend = 199
+#     livetime[0] += 1
+#     endif
+#     livetime[istart:iend] += 1
+#     endif
+#     endfor
+def get_expo_corr(evfile, parfile, nbin=128, n_phot_max=None):
+    cache_file = os.path.basename(
+            os.path.splitext(evfile)[0]) + f'_expo_{nbin}.pickle'
+    if cache_file is not None and os.path.exists(cache_file):
+        log.info("Using cached exposure information")
+        return pickle.load(open(cache_file, 'rb'))
+    if n_phot_max is None:
+        n_phot_max = 500 * nbin
+
+    # ephem = get_model(parfile)
+
+    with fits.open(evfile) as hdul:
+        times = np.array(hdul[1].data['TIME'][:n_phot_max])
+        priors = np.array(hdul[1].data['PRIOR'][:n_phot_max])
+        mjdref = hdul[1].header['MJDREFF'] + hdul[1].header['MJDREFI']
+
+    hdul.close()
+
+    expo = get_exposure_per_bin(times, priors, parfile,
+                         nbin=nbin, cache_file=cache_file, mjdref=mjdref)
+    return expo
+
+
+def get_exposure_per_bin(event_times, event_priors, parfile,
+                         nbin=16, cache_file=None, mjdref=0):
+    """
+    Examples
+    --------
+    # >>> event_times = np.arange(1, 10, 0.01)
+    # >>> event_priors = np.zeros_like(event_times)
+    # >>> event_priors[0] = 1
+    # >>> prof = get_exposure_per_bin(event_times, event_priors, 1/10, nbin=10)
+    # >>> prof[0]
+    # 0
+    # >>> np.allclose(prof[1:], 1)
+    # True
+    """
+    log.info("Calculating exposure")
+
+    if cache_file is not None and os.path.exists(cache_file):
+        log.info("Using cached exposure information")
+        return pickle.load(open(cache_file, 'rb'))
+
+    start_live_time = event_times - event_priors
+
+    m = get_model(parfile)
+
+    sampling_time = 1 / m.F0.value / nbin / 7.1234514351515132414
+    chunk_size = np.min((sampling_time * 50000000, 1000))
+    mjdstart = (event_times[0] - 10) / 86400 + mjdref
+    mjdstop = (event_times[-1] + 10) / 86400 + mjdref
+
+    phase_correction_fun = get_phase_from_ephemeris_file(mjdstart, mjdstop,
+                                                         parfile)
+
+    prof_all = 0
+    prof_dead = 0
+    for start_time in tqdm.tqdm(np.arange(start_live_time[0], event_times[-1], chunk_size)):
+        sample_times = np.arange(start_time, start_time + chunk_size, sampling_time)
+
+        idxs_live = np.searchsorted(start_live_time, sample_times, side='right')
+        idxs_dead = np.searchsorted(event_times, sample_times, side='right')
+
+        dead = idxs_live == idxs_dead
+
+        sample_times = sample_times / 86400 + mjdref
+        # phases_all = _fast_phase_fddot(sample_times, freq, fdot, fddot)
+        # phases_dead = _fast_phase_fddot(sample_times[dead], freq, fdot, fddot)
+        phases_all = phase_correction_fun(sample_times)
+        # phases_dead = phase_correction_fun(sample_times[dead])
+        phases_all = phases_all - np.floor(phases_all)
+        phases_dead = phases_all[dead]
+
+        prof_all += histogram(phases_all.astype(np.double), bins=nbin, ranges=[0, 1])
+        prof_dead += histogram(phases_dead.astype(np.double), bins=nbin, ranges=[0, 1])
+
+    expo = (prof_all - prof_dead) / prof_all
+
+    if cache_file is not None:
+        pickle.dump(expo, open(cache_file, 'wb'))
+
+    return expo
 
 
 def get_phase_from_ephemeris_file(mjdstart, mjdstop, parfile,
@@ -134,6 +243,9 @@ def main(args=None):
                         help="Maximum energy of photons, in keV")
     parser.add_argument('--n-phot-max', default=None, type=int,
                         help="Maximum number of photons")
+    parser.add_argument("--expocorr", default=None, type=str,
+                        help="Unfiltered file to calculate the exposure from "
+                             "(NuSTAR only)")
 
     args = parser.parse_args(args)
 
@@ -148,7 +260,22 @@ def main(args=None):
         n_phot_max = n_phot_per_bin * nbin
 
     ephem = get_ephemeris_from_parfile(args.parfile)
-
+    expo = None
+    if args.expocorr is not None:
+        if args.expocorr.endswith('pickle'):
+            expo = pickle.load(open(args.expocorr, 'rb'))
+            if expo.size < nbin:
+                log.warning("Interpolating exposure. Use at your own risk.")
+        else:
+            expo = get_expo_corr(
+                args.expocorr, args.parfile,
+                nbin=nbin * 4, n_phot_max=300 * 4 * nbin)
+        if expo.size != nbin:
+            expo_fun = interp1d(
+                np.linspace(0, 1, expo.size + 1) + 0.5 / expo.size,
+                np.concatenate((expo, [expo[0]])))
+            expo = expo_fun(
+                np.linspace(0, 1, nbin + 1)[:nbin] + 0.5 / nbin)
     log.info(f"Loading {evfile}")
     events = get_events_from_fits(evfile)
 
@@ -166,7 +293,8 @@ def main(args=None):
     mjdstop = events_time[-1] + 0.01
 
     log.info("Calculating correction function...")
-    correction_fun = get_phase_from_ephemeris_file(mjdstart, mjdstop, args.parfile)
+    correction_fun = \
+        get_phase_from_ephemeris_file(mjdstart, mjdstop, args.parfile)
 
     del events
 
@@ -179,11 +307,13 @@ def main(args=None):
 
         phase = correction_fun(local_events)
 
-        t = calculate_profile_from_phase(phase, nbin=nbin)
+        t = calculate_profile_from_phase(phase, nbin=nbin, expo=expo)
 
         label = f'{event_start}-{event_start + n_phot_max}'
         if emin is not None or emax is not None:
             label += f'_{emin}-{emax}keV'
+        if args.expocorr:
+            label += '_deadcorr'
 
         for attr in ['F0', 'F1', 'F2']:
             t.meta[attr] = getattr(ephem, attr).value
@@ -193,9 +323,18 @@ def main(args=None):
         t.write(os.path.splitext(evfile)[0] + f'_{label}.ecsv', overwrite=True)
 
         fig = plt.figure()
-        plt.plot(t['phase'], t['profile'], label='corrected')
+        plt.title(f"MJD {t.meta['mjd']}")
+        phase = np.concatenate((t['phase'], t['phase'] + 1))
+        profile = np.concatenate((t['profile'], t['profile']))
+        plt.plot(phase, profile, label='corrected')
+        if args.expocorr:
+            profile_raw = np.concatenate((t['profile_raw'], t['profile_raw']))
+            expo = np.concatenate((t['expo'], t['expo']))
 
-        plt.legend()
+            plt.plot(phase, profile_raw, alpha=0.5, label='raw')
+            plt.plot(phase, expo * np.max(t['profile']),
+                     alpha=0.5, label='expo')
+            plt.legend()
         plt.savefig(os.path.splitext(evfile)[0] + f'_{label}.png', overwrite=True)
         plt.close(fig)
 

--- a/nuclockutils/nustarclock.py
+++ b/nuclockutils/nustarclock.py
@@ -939,7 +939,7 @@ class ClockCorrection():
                 idx0, idx1 = np.searchsorted(
                     allmets, [jumptime - twodays, jumptime + twodays])
                 # print(idx0, idx1)
-                good_for_clockfile[idx0:idx1] = True
+                good_for_clockfile[idx0:idx1:10] = True
             new_clock_table_subsample = new_clock_table[good_for_clockfile]
         else:
             new_clock_table_subsample = new_clock_table

--- a/nuclockutils/nustarclock.py
+++ b/nuclockutils/nustarclock.py
@@ -1406,15 +1406,8 @@ def temperature_delay(temptable, divisor,
         print(table_times.min(), table_times.max())
         raise
 
-<<<<<<< HEAD
     clock_rate_corr = (1 + ppm_mod / 1000000) * 24000000 / divisor - 1
 
-=======
-    # clock_rate_corr = (1 + ppm_mod / 1000000) * 24000000 / divisor - 1
-    clock_rate_corr = (1 + ppm_mod / 1000000) * 24000334 / divisor - 1
-    # clock_rate_corr = (1 + ppm_mod / 1000000) - 1
-    # print(clock_rate_corr)
->>>>>>> dbbf6fe... Add fixed control points machinery; use new solution based on average divisor 24000334
     delay_sim = simpcumquad(times_fine, clock_rate_corr)
     return interp1d(times_fine, delay_sim, fill_value='extrapolate',
                     bounds_error=False)

--- a/nuclockutils/utils.py
+++ b/nuclockutils/utils.py
@@ -243,7 +243,7 @@ def rolling_std(a, window, pad='center'):
 
 
 def spline_through_data(x, y, k=2, grace_intv=1000., smoothing_factor=0.001,
-                        downsample=10):
+                        downsample=10, fixed_control_points=None):
     """Pass a spline through the data
 
     Examples
@@ -259,12 +259,16 @@ def spline_through_data(x, y, k=2, grace_intv=1000., smoothing_factor=0.001,
     control_points = \
         np.linspace(lo_lim + 2 * grace_intv, hi_lim - 2 * grace_intv,
                     x.size // downsample)
+    if fixed_control_points is not None and len(fixed_control_points) > 0:
+        print(f'Adding control points: {fixed_control_points}')
+        control_points = np.sort(
+            np.concatenate((control_points, fixed_control_points)))
 
     detrend_fun = LSQUnivariateSpline(
         x, y, t=control_points, k=k,
         bbox=[lo_lim - grace_intv, hi_lim + grace_intv])
 
-    detrend_fun.set_smoothing_factor(smoothing_factor)
+    # detrend_fun.set_smoothing_factor(smoothing_factor)
 
     return detrend_fun
 

--- a/nuclockutils/utils.py
+++ b/nuclockutils/utils.py
@@ -266,9 +266,7 @@ def spline_through_data(x, y, k=2, grace_intv=1000., smoothing_factor=0.001,
 
     detrend_fun = LSQUnivariateSpline(
         x, y, t=control_points, k=k,
-        bbox=[lo_lim - grace_intv, hi_lim + grace_intv])
-
-    # detrend_fun.set_smoothing_factor(smoothing_factor)
+        bbox=[lo_lim, hi_lim])
 
     return detrend_fun
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,8 @@ nustar_plot_diagnostics = nuclockutils.nustarclock:main_plot_diagnostics
 nustar_test_new_clockfile = nuclockutils.diagnostics.bary_and_fold_all:main
 nustar_compare_pulses = nuclockutils.diagnostics.compare_pulses:main
 nustar_compare_clock_files = nuclockutils.diagnostics.compare_clock_files:main
+nustar_get_crab_ephemeris = nuclockutils.diagnostics.get_crab_ephemeris:main
+nustar_fold_to_ephemeris = nuclockutils.diagnostics.fold_to_ephemeris:main
 
 [config.logging_helper]
 # Threshold for the logging messages. Logging messages that are less severe


### PR DESCRIPTION
1. Separates the high-resolution clock file machinery in  #18 from the different divisor reference;
2. Fixes the problem of the spline fitting at the end of the solution

Tested on the test data, the performance is indeed slightly better, giving ~10us stability on short (orbital) time scales.
I'm not sure it's worth the large size, but having the option is better than not having it. Also, it's good for testing purposes.

From my tests: 

+ Crab scatter over the full history 60->40 us
+ B1821-24A consistently narrower profile
+ B1937+21 consistently narrower profile
