### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,8 @@ scipy
 astropy>=3.2,!=4.0.1,!=4.0.1.post1
 matplotlib
 pandas
-sklearn
-pint-pulsar
-#git+https://github.com/nanograv/pint.git@e5f6b260422898f63c88d636712fcc1cdd76cf20
+scikit-learn
+pint-pulsar=0.7
 tqdm
 jplephem
 datashader
@@ -14,4 +13,4 @@ holoviews
 statsmodels
 h5py
 astroquery
-
+dash


### PR DESCRIPTION
For a clean install, currently pins PINT to v0.7 (see #42) until this gets refactored.

Added dash so that also gets installed.

Updated scikit-learn to match conda install syntax